### PR TITLE
Fix crash when seeking close to end of media file

### DIFF
--- a/FFVideoTrack.m
+++ b/FFVideoTrack.m
@@ -89,11 +89,14 @@
 - (BOOL)putPacket:(const AVPacket*)packet
 {
     //TRACE(@"%s", __PRETTY_FUNCTION__);
+    [_mutex lock];
     if ([self isFull]) {
+        [_mutex unlock];
         return FALSE;
     }
     _packet[_rear] = *packet;
     _rear = (_rear + 1) % _capacity;
+    [_mutex unlock];
     return TRUE;
 }
 

--- a/FFVideoTrack.m
+++ b/FFVideoTrack.m
@@ -78,7 +78,9 @@
     [_mutex lock];
     unsigned int i;
     for (i = _front; i != _rear; i = (i + 1) % _capacity) {
-        av_free_packet(&_packet[i]);
+        if (_packet[i].data != s_flushPacket.data) {
+            av_free_packet(&_packet[i]);
+        }
     }
     _rear = _front; 
     [_mutex unlock];


### PR DESCRIPTION
Movist has for a long time had a problem where seeking forward when the play position was very close to the end of the file could make the app crash. The reason turned out to be that in order to flush the FFmpeg decoder buffer queue, a special statically allocated marker packet was inserted into the queue. If the queue itself was `dealloc:`ed when this packet was in the queue, the marker packet would be passed to `av_free_packet` which would then trigger the OS malloc checks.

Also lock the mutex in `[PacketQueue putPacket:]`, because it's used everywhere else.